### PR TITLE
fix: improve dialog width

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -56,7 +56,7 @@ const modalPositionStyles = cva(
 
 const modalContentStyles = cva(
   [
-    "flex flex-col bg-surface-surface-0 border border-outline-base-em rounded-16 shadow-6 overflow-hidden",
+    "flex flex-col w-full bg-surface-surface-0 border border-outline-base-em rounded-16 shadow-6 overflow-hidden",
   ],
   {
     variants: {
@@ -77,10 +77,12 @@ const DialogContent = React.forwardRef<
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
-      className={modalPositionStyles({ append, className })}
+      className={modalPositionStyles({ append })}
       {...props}
     >
-      <div className={modalContentStyles({ append })}>{children}</div>
+      <div className={modalContentStyles({ append, className })}>
+        {children}
+      </div>
     </DialogPrimitive.Content>
   </DialogPortal>
 ));


### PR DESCRIPTION
Dialog width outside swapr-ui is breaking. The Dialog width collapses to fit content.

To fix this PR adds:

- Full width to dialog inner div.
- Class name control to dialog inner div.